### PR TITLE
Save result from jax.local_device_count

### DIFF
--- a/nerfies/utils.py
+++ b/nerfies/utils.py
@@ -334,7 +334,7 @@ def general_loss_with_squared_residual(squared_x, alpha, scale):
 def shard(xs, device_count=None):
   """Split data into shards for multiple devices along the first dimension."""
   if device_count is None:
-    jax.local_device_count()
+    device_count = jax.local_device_count()
   return jax.tree_map(lambda x: x.reshape((device_count, -1) + x.shape[1:]), xs)
 
 


### PR DESCRIPTION
`jax.local_device_count()` result is discarded here, but I do not believe there is a way to reach this codepath (currently there are no usages of `utils.shard(...)` missing the `device_count` arg) 